### PR TITLE
feat: detect headless environments and skip OAuth listener

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -115,29 +115,47 @@ export const GeminiCLIOAuthPlugin = async (
         authorize: async () => {
           console.log("\n=== Google Gemini OAuth Setup ===");
 
+          // Detect headless/SSH environment
+          const isHeadless = !!(
+            process.env.SSH_CONNECTION ||
+            process.env.SSH_CLIENT ||
+            process.env.SSH_TTY ||
+            process.env.OPENCODE_HEADLESS
+          );
+
           let listener: OAuthListener | null = null;
-          try {
-            listener = await startOAuthListener();
-            const { host } = new URL(GEMINI_REDIRECT_URI);
-            console.log("1. You'll be asked to sign in to your Google account and grant permission.");
-            console.log(
-              `2. We'll automatically capture the browser redirect on http://${host}. No need to paste anything back here.`,
-            );
-            console.log("3. Once you see the 'Authentication complete' page in your browser, return to this terminal.");
-          } catch (error) {
-            console.log("1. You'll be asked to sign in to your Google account and grant permission.");
-            console.log("2. After you approve, the browser will try to redirect to a 'localhost' page.");
-            console.log(
-              "3. This page will show an error like 'This site can’t be reached'. This is perfectly normal and means it worked!",
-            );
-            console.log(
-              "4. Once you see that error, copy the entire URL from the address bar, paste it back here, and press Enter.",
-            );
-            if (error instanceof Error) {
-              console.log(`\nWarning: Couldn't start the local callback listener (${error.message}). Falling back to manual copy/paste.`);
-            } else {
-              console.log("\nWarning: Couldn't start the local callback listener. Falling back to manual copy/paste.");
+          if (!isHeadless) {
+            try {
+              listener = await startOAuthListener();
+              const { host } = new URL(GEMINI_REDIRECT_URI);
+              console.log("1. You'll be asked to sign in to your Google account and grant permission.");
+              console.log(
+                `2. We'll automatically capture the browser redirect on http://${host}. No need to paste anything back here.`,
+              );
+              console.log("3. Once you see the 'Authentication complete' page in your browser, return to this terminal.");
+            } catch (error) {
+              console.log("1. You'll be asked to sign in to your Google account and grant permission.");
+              console.log("2. After you approve, the browser will try to redirect to a 'localhost' page.");
+              console.log(
+                "3. This page will show an error like 'This site can't be reached'. This is perfectly normal and means it worked!",
+              );
+              console.log(
+                "4. Once you see that error, copy the entire URL from the address bar, paste it back here, and press Enter.",
+              );
+              if (error instanceof Error) {
+                console.log(`\nWarning: Couldn't start the local callback listener (${error.message}). Falling back to manual copy/paste.`);
+              } else {
+                console.log("\nWarning: Couldn't start the local callback listener. Falling back to manual copy/paste.");
+              }
             }
+          } else {
+            console.log("Headless environment detected. Using manual OAuth flow.");
+            console.log("1. You'll be asked to sign in to your Google account and grant permission.");
+            console.log("2. After you approve, the browser will redirect to a 'localhost' URL.");
+            console.log(
+              "3. Copy the ENTIRE URL from your browser's address bar (it will look like: http://localhost:8085/oauth2callback?code=...&state=...)",
+            );
+            console.log("4. Paste the URL back here and press Enter.");
           }
           console.log("\n");
 


### PR DESCRIPTION
## Summary

Improves the OAuth setup experience in headless/SSH environments by detecting these environments and skipping the local OAuth callback listener attempt, avoiding unnecessary fallback warnings.

## Changes

- Detects headless environments by checking for `SSH_CONNECTION`, `SSH_CLIENT`, `SSH_TTY`, or `OPENCODE_HEADLESS` environment variables
- Skips local callback listener in headless mode and goes directly to manual OAuth flow
- Provides clearer instructions for headless users with improved messaging
- Maintains backward compatibility - non-headless environments still use automatic callback listener

## Motivation

Previously, when running in SSH/headless environments, the plugin would attempt to start a local OAuth callback listener, fail, and then fall back to manual mode with warnings. This creates a confusing user experience with unnecessary error messages. This change detects headless environments upfront and uses the appropriate OAuth flow from the start.

## Testing

Tested in headless environment with `OPENCODE_HEADLESS=1` - OAuth flow works smoothly without fallback warnings and provides clear manual instructions.