### PR TITLE
docs: add gemini-3-flash-preview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Alternatively, you can manually remove the dependency from `~/.cache/opencode/pa
 
 This plugin supports configuring "thinking" capabilities for Gemini models via the `thinkingConfig` option.
 
-*   **Gemini 3 models** use `thinkingLevel` (string: `'low'`, `'medium'`, `'high'`).
+*   **Gemini 3 models** (`gemini-3-pro-preview`, `gemini-3-flash-preview`) use `thinkingLevel` (string: `'low'`, `'medium'`, `'high'`).
 *   **Gemini 2.5 models** use `thinkingBudget` (number).
 
 The plugin passes these values through to the API as configured.
@@ -61,6 +61,14 @@ The plugin passes these values through to the API as configured.
           "options": {
             "thinkingConfig": {
               "thinkingLevel": "high",
+              "includeThoughts": true
+            }
+          }
+        },
+        "gemini-3-flash-preview": {
+          "options": {
+            "thinkingConfig": {
+              "thinkingLevel": "medium",
               "includeThoughts": true
             }
           }


### PR DESCRIPTION
## Summary
- Add `gemini-3-flash-preview` to the list of supported Gemini 3 models in the documentation
- Include a configuration example showing `thinkingLevel` usage for the new model

## Test plan
- [x] Verified plugin code already supports this model via dynamic regex matching
- [ ] Review documentation changes for accuracy