### PR TITLE
feat: add multi-account profile switching

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@openauthjs/openauth": "^0.4.3",
       },
       "devDependencies": {
-        "@opencode-ai/plugin": "^1.0.184",
+        "@opencode-ai/plugin": "^1.0.203",
         "@types/bun": "latest",
       },
       "peerDependencies": {

--- a/index.ts
+++ b/index.ts
@@ -12,3 +12,16 @@ export type {
   GeminiAuthorization,
   GeminiTokenExchangeResult,
 } from "./src/gemini/oauth";
+
+// Profile management exports
+export {
+  listProfiles,
+  saveProfile,
+  useProfile,
+  deleteProfile,
+  getProfile,
+  getActiveProfileName,
+  currentInfo,
+} from "./src/plugin/profiles";
+
+export type { Profile, ProfileResult } from "./src/plugin/profiles";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-gemini-auth",
   "module": "index.ts",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "author": "jenslys",
   "repository": "https://github.com/jenslys/opencode-gemini-auth",
   "files": [
@@ -10,6 +10,9 @@
   ],
   "license": "MIT",
   "type": "module",
+  "bin": {
+    "gemini-swap": "./src/cli.ts"
+  },
   "devDependencies": {
     "@opencode-ai/plugin": "^1.0.203",
     "@types/bun": "latest"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env bun
+/**
+ * CLI for managing Google account profiles for opencode.
+ *
+ * Usage:
+ *   gemini-swap list                    - List all saved profiles
+ *   gemini-swap save <name> [projectId] - Save current config as a profile
+ *   gemini-swap use <name>              - Switch to a profile
+ *   gemini-swap current                 - Show current configuration
+ *   gemini-swap delete <name>           - Delete a profile
+ *   gemini-swap help                    - Show this help message
+ */
+
+import {
+  listProfiles,
+  saveProfile,
+  useProfile,
+  deleteProfile,
+  currentInfo,
+  getActiveProfileName,
+} from "./plugin/profiles";
+
+function printUsage(): void {
+  console.log(`
+Gemini Account Swap - Manage Google accounts for OpenCode
+
+Usage:
+  gemini-swap list                    - List all saved profiles
+  gemini-swap save <name> [projectId] - Save current config as a profile
+  gemini-swap use <name>              - Switch to a profile
+  gemini-swap current                 - Show current configuration
+  gemini-swap delete <name>           - Delete a profile
+  gemini-swap help, -h, --help        - Show this help message
+
+Examples:
+  gemini-swap save work my-work-project-123
+  gemini-swap save personal my-personal-project-456
+  gemini-swap use work
+  gemini-swap list
+`);
+}
+
+function cmdList(): void {
+  const profiles = listProfiles();
+  const active = getActiveProfileName();
+
+  if (profiles.length === 0) {
+    console.log("No profiles saved yet.");
+    console.log("Use 'gemini-swap save <name> [projectId]' to save current config.");
+    return;
+  }
+
+  console.log("Saved profiles:");
+  for (const profile of profiles) {
+    const marker = profile.name === active ? " (active)" : "";
+    const lastUsed = profile.lastUsed
+      ? new Date(profile.lastUsed).toLocaleDateString()
+      : "never";
+    console.log(`  - ${profile.name}${marker}`);
+    console.log(`      projectId: ${profile.projectId}`);
+    console.log(`      lastUsed: ${lastUsed}`);
+  }
+}
+
+function cmdSave(name: string | undefined, projectId: string | undefined): void {
+  if (!name) {
+    console.error("Error: Profile name required.");
+    console.log("Usage: gemini-swap save <name> [projectId]");
+    process.exit(1);
+  }
+
+  const result = saveProfile(name, projectId);
+  if (result.success) {
+    console.log(result.message);
+  } else {
+    console.error(`Error: ${result.message}`);
+    process.exit(1);
+  }
+}
+
+function cmdUse(name: string | undefined): void {
+  if (!name) {
+    console.error("Error: Profile name required.");
+    console.log("Usage: gemini-swap use <name>");
+    process.exit(1);
+  }
+
+  const result = useProfile(name);
+  if (result.success) {
+    console.log(result.message);
+  } else {
+    console.error(`Error: ${result.message}`);
+    process.exit(1);
+  }
+}
+
+function cmdDelete(name: string | undefined): void {
+  if (!name) {
+    console.error("Error: Profile name required.");
+    console.log("Usage: gemini-swap delete <name>");
+    process.exit(1);
+  }
+
+  const result = deleteProfile(name);
+  if (result.success) {
+    console.log(result.message);
+  } else {
+    console.error(`Error: ${result.message}`);
+    process.exit(1);
+  }
+}
+
+function cmdCurrent(): void {
+  const info = currentInfo();
+  console.log("Current configuration:");
+  console.log(`  Active profile: ${info.activeProfile ?? "(none)"}`);
+  console.log(`  Project ID: ${info.projectId ?? "(not set)"}`);
+  console.log(`  Refresh token: ${info.refreshToken ?? "(not logged in)"}`);
+}
+
+// Main
+const args = process.argv.slice(2);
+const command = args[0]?.toLowerCase();
+
+switch (command) {
+  case "list":
+  case "ls":
+    cmdList();
+    break;
+  case "save":
+  case "add":
+    cmdSave(args[1], args[2]);
+    break;
+  case "use":
+  case "switch":
+    cmdUse(args[1]);
+    break;
+  case "delete":
+  case "rm":
+  case "remove":
+    cmdDelete(args[1]);
+    break;
+  case "current":
+  case "status":
+    cmdCurrent();
+    break;
+  case "help":
+  case "-h":
+  case "--help":
+  case undefined:
+    printUsage();
+    break;
+  default:
+    console.error(`Unknown command: ${command}`);
+    printUsage();
+    process.exit(1);
+}

--- a/src/plugin/profiles.test.ts
+++ b/src/plugin/profiles.test.ts
@@ -1,0 +1,550 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  setConfig,
+  resetConfig,
+  getConfig,
+  listProfiles,
+  saveProfile,
+  useProfile,
+  deleteProfile,
+  getProfile,
+  getActiveProfileName,
+  currentInfo,
+  getCurrentRefreshToken,
+  getCurrentProjectId,
+  setRefreshToken,
+  setProjectId,
+  loadProfilesStore,
+  saveProfilesStore,
+  type ProfileManagerConfig,
+  type Profile,
+} from "./profiles";
+
+// Create a unique temp directory for each test run
+function createTempConfig(): ProfileManagerConfig {
+  const configDir = join(tmpdir(), `opencode-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(configDir, { recursive: true });
+  return {
+    configDir,
+    profilesFile: join(configDir, "gemini-profiles.json"),
+    accountsFile: join(configDir, "antigravity-accounts.json"),
+    configFile: join(configDir, "config.json"),
+  };
+}
+
+// Clean up temp directory
+function cleanupTempConfig(config: ProfileManagerConfig): void {
+  try {
+    rmSync(config.configDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+// Helper to create mock accounts file
+function createMockAccountsFile(config: ProfileManagerConfig, refreshToken: string): void {
+  const data = {
+    version: 3,
+    accounts: [
+      {
+        refreshToken,
+        addedAt: Date.now(),
+        lastUsed: Date.now(),
+        rateLimitResetTimes: {},
+      },
+    ],
+    activeIndex: 0,
+    activeIndexByFamily: { claude: 0, gemini: 0 },
+  };
+  writeFileSync(config.accountsFile, JSON.stringify(data, null, 2));
+}
+
+// Helper to create mock config file
+function createMockConfigFile(config: ProfileManagerConfig, projectId: string): void {
+  const data = {
+    "$schema": "https://opencode.ai/config.json",
+    plugin: ["opencode-gemini-auth-swap@latest"],
+    provider: {
+      google: {
+        options: {
+          projectId,
+        },
+      },
+    },
+  };
+  writeFileSync(config.configFile, JSON.stringify(data, null, 2));
+}
+
+describe("profiles", () => {
+  let tempConfig: ProfileManagerConfig;
+
+  beforeEach(() => {
+    tempConfig = createTempConfig();
+    setConfig(tempConfig);
+  });
+
+  afterEach(() => {
+    resetConfig();
+    cleanupTempConfig(tempConfig);
+  });
+
+  describe("config management", () => {
+    it("should set and get config", () => {
+      const config = getConfig();
+      expect(config.configDir).toBe(tempConfig.configDir);
+      expect(config.profilesFile).toBe(tempConfig.profilesFile);
+    });
+
+    it("should reset to default config", () => {
+      resetConfig();
+      const config = getConfig();
+      expect(config.configDir).toContain(".config/opencode");
+      // Reset back to temp for cleanup
+      setConfig(tempConfig);
+    });
+  });
+
+  describe("getCurrentRefreshToken", () => {
+    it("should return undefined when accounts file does not exist", () => {
+      expect(getCurrentRefreshToken()).toBeUndefined();
+    });
+
+    it("should return refresh token from accounts file", () => {
+      createMockAccountsFile(tempConfig, "test-refresh-token-123");
+      expect(getCurrentRefreshToken()).toBe("test-refresh-token-123");
+    });
+
+    it("should return token at activeIndex", () => {
+      const data = {
+        version: 3,
+        accounts: [
+          { refreshToken: "token-0", addedAt: 1, lastUsed: 1, rateLimitResetTimes: {} },
+          { refreshToken: "token-1", addedAt: 1, lastUsed: 1, rateLimitResetTimes: {} },
+        ],
+        activeIndex: 1,
+        activeIndexByFamily: { claude: 0, gemini: 1 },
+      };
+      writeFileSync(tempConfig.accountsFile, JSON.stringify(data));
+      expect(getCurrentRefreshToken()).toBe("token-1");
+    });
+
+    it("should handle malformed JSON gracefully", () => {
+      writeFileSync(tempConfig.accountsFile, "not valid json");
+      expect(getCurrentRefreshToken()).toBeUndefined();
+    });
+  });
+
+  describe("getCurrentProjectId", () => {
+    it("should return undefined when config file does not exist", () => {
+      expect(getCurrentProjectId()).toBeUndefined();
+    });
+
+    it("should return project ID from config file", () => {
+      createMockConfigFile(tempConfig, "my-project-123");
+      expect(getCurrentProjectId()).toBe("my-project-123");
+    });
+
+    it("should handle missing nested properties", () => {
+      writeFileSync(tempConfig.configFile, JSON.stringify({ provider: {} }));
+      expect(getCurrentProjectId()).toBeUndefined();
+    });
+
+    it("should handle malformed JSON gracefully", () => {
+      writeFileSync(tempConfig.configFile, "invalid json");
+      expect(getCurrentProjectId()).toBeUndefined();
+    });
+  });
+
+  describe("setRefreshToken", () => {
+    it("should create accounts file if it does not exist", () => {
+      expect(setRefreshToken("new-token")).toBe(true);
+      expect(existsSync(tempConfig.accountsFile)).toBe(true);
+      expect(getCurrentRefreshToken()).toBe("new-token");
+    });
+
+    it("should update existing token", () => {
+      createMockAccountsFile(tempConfig, "old-token");
+      expect(setRefreshToken("new-token")).toBe(true);
+      expect(getCurrentRefreshToken()).toBe("new-token");
+    });
+
+    it("should preserve other account data", () => {
+      createMockAccountsFile(tempConfig, "old-token");
+      setRefreshToken("new-token");
+      const data = JSON.parse(readFileSync(tempConfig.accountsFile, "utf-8"));
+      expect(data.version).toBe(3);
+      expect(data.accounts[0].refreshToken).toBe("new-token");
+      expect(data.accounts[1].refreshToken).toBe("old-token");
+      expect(data.activeIndex).toBe(0);
+      expect(data.activeIndexByFamily.gemini).toBe(0);
+    });
+  });
+
+  describe("setProjectId", () => {
+    it("should create config file if it does not exist", () => {
+      expect(setProjectId("new-project")).toBe(true);
+      expect(existsSync(tempConfig.configFile)).toBe(true);
+      expect(getCurrentProjectId()).toBe("new-project");
+    });
+
+    it("should update existing project ID", () => {
+      createMockConfigFile(tempConfig, "old-project");
+      expect(setProjectId("new-project")).toBe(true);
+      expect(getCurrentProjectId()).toBe("new-project");
+    });
+
+    it("should preserve other config data", () => {
+      createMockConfigFile(tempConfig, "old-project");
+      setProjectId("new-project");
+      const data = JSON.parse(readFileSync(tempConfig.configFile, "utf-8"));
+      expect(data["$schema"]).toBe("https://opencode.ai/config.json");
+      expect(data.plugin).toContain("opencode-gemini-auth-swap@latest");
+    });
+  });
+
+  describe("listProfiles", () => {
+    it("should return empty array when no profiles exist", () => {
+      expect(listProfiles()).toEqual([]);
+    });
+
+    it("should return saved profiles", () => {
+      const store = {
+        version: 1,
+        profiles: [
+          { name: "work", refreshToken: "t1", projectId: "p1", createdAt: 1 },
+          { name: "personal", refreshToken: "t2", projectId: "p2", createdAt: 2 },
+        ],
+      };
+      saveProfilesStore(store);
+      const profiles = listProfiles();
+      expect(profiles).toHaveLength(2);
+      expect(profiles[0]?.name).toBe("work");
+      expect(profiles[1]?.name).toBe("personal");
+    });
+  });
+
+  describe("saveProfile", () => {
+    it("should fail when no refresh token exists", () => {
+      const result = saveProfile("test", "project-123");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("No active OAuth session");
+    });
+
+    it("should fail when no project ID provided and none in config", () => {
+      createMockAccountsFile(tempConfig, "token-123");
+      const result = saveProfile("test");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("No project ID found");
+    });
+
+    it("should save profile with explicit project ID", () => {
+      createMockAccountsFile(tempConfig, "token-123");
+      const result = saveProfile("work", "my-project");
+      expect(result.success).toBe(true);
+      expect(result.profile?.name).toBe("work");
+      expect(result.profile?.projectId).toBe("my-project");
+      expect(result.profile?.refreshToken).toBe("token-123");
+    });
+
+    it("should use project ID from config if not provided", () => {
+      createMockAccountsFile(tempConfig, "token-123");
+      createMockConfigFile(tempConfig, "config-project");
+      const result = saveProfile("work");
+      expect(result.success).toBe(true);
+      expect(result.profile?.projectId).toBe("config-project");
+    });
+
+    it("should set active profile after saving", () => {
+      createMockAccountsFile(tempConfig, "token-123");
+      saveProfile("work", "project");
+      expect(getActiveProfileName()).toBe("work");
+    });
+
+    it("should update existing profile", () => {
+      createMockAccountsFile(tempConfig, "token-1");
+      saveProfile("work", "project-1");
+      const firstCreatedAt = getProfile("work")?.createdAt;
+
+      createMockAccountsFile(tempConfig, "token-2");
+      saveProfile("work", "project-2");
+
+      const profile = getProfile("work");
+      expect(profile?.refreshToken).toBe("token-2");
+      expect(profile?.projectId).toBe("project-2");
+      expect(profile?.createdAt).toBe(firstCreatedAt); // Should preserve original createdAt
+    });
+
+    it("should add multiple profiles", () => {
+      createMockAccountsFile(tempConfig, "token-1");
+      saveProfile("work", "project-1");
+
+      createMockAccountsFile(tempConfig, "token-2");
+      saveProfile("personal", "project-2");
+
+      expect(listProfiles()).toHaveLength(2);
+    });
+  });
+
+  describe("getProfile", () => {
+    it("should return undefined for non-existent profile", () => {
+      expect(getProfile("nonexistent")).toBeUndefined();
+    });
+
+    it("should return profile by name", () => {
+      createMockAccountsFile(tempConfig, "token");
+      saveProfile("work", "project");
+      const profile = getProfile("work");
+      expect(profile?.name).toBe("work");
+      expect(profile?.projectId).toBe("project");
+    });
+  });
+
+  describe("useProfile", () => {
+    it("should fail for non-existent profile", () => {
+      const result = useProfile("nonexistent");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("not found");
+    });
+
+    it("should list available profiles in error message", () => {
+      createMockAccountsFile(tempConfig, "token");
+      saveProfile("work", "project");
+      const result = useProfile("nonexistent");
+      expect(result.message).toContain("work");
+    });
+
+    it("should switch to profile and update files", () => {
+      // Save first profile
+      createMockAccountsFile(tempConfig, "token-1");
+      createMockConfigFile(tempConfig, "project-1");
+      saveProfile("work", "project-1");
+
+      // Save second profile
+      createMockAccountsFile(tempConfig, "token-2");
+      saveProfile("personal", "project-2");
+
+      // Switch back to first profile
+      const result = useProfile("work");
+      expect(result.success).toBe(true);
+      expect(getCurrentRefreshToken()).toBe("token-1");
+      expect(getCurrentProjectId()).toBe("project-1");
+    });
+
+    it("should update active profile name", () => {
+      createMockAccountsFile(tempConfig, "token");
+      saveProfile("work", "project");
+      saveProfile("personal", "project-2");
+
+      useProfile("work");
+      expect(getActiveProfileName()).toBe("work");
+
+      useProfile("personal");
+      expect(getActiveProfileName()).toBe("personal");
+    });
+
+    it("should update lastUsed timestamp", async () => {
+      createMockAccountsFile(tempConfig, "token");
+      saveProfile("work", "project");
+
+      const before = getProfile("work")?.lastUsed ?? 0;
+
+      // Wait a tiny bit to ensure time difference
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      useProfile("work");
+      const after = getProfile("work")?.lastUsed ?? 0;
+
+      expect(after).toBeGreaterThanOrEqual(before);
+    });
+
+    it("should correctly switch between multiple existing accounts", () => {
+      // 1. Create an accounts file with two accounts
+      const accountsData = {
+        version: 3,
+        accounts: [
+          { refreshToken: "token-work", addedAt: 1, lastUsed: 1, rateLimitResetTimes: {} },
+          { refreshToken: "token-personal", addedAt: 1, lastUsed: 1, rateLimitResetTimes: {} },
+        ],
+        activeIndex: 0,
+        activeIndexByFamily: { claude: 0, gemini: 0 },
+      };
+      writeFileSync(tempConfig.accountsFile, JSON.stringify(accountsData));
+    
+      // 2. Save two profiles, one for each token
+      saveProfile("work", "project-work");
+      // Manually set the refresh token for the second profile since saveProfile would overwrite it
+      const store = loadProfilesStore();
+      store.profiles.push({
+        name: "personal",
+        refreshToken: "token-personal",
+        projectId: "project-personal",
+        createdAt: Date.now(),
+        lastUsed: Date.now(),
+      });
+      saveProfilesStore(store);
+    
+    
+      // 3. Use the "personal" profile
+      useProfile("personal");
+    
+      // 4. Verify that the activeIndex in antigravity-accounts.json is 0 and personal token is first
+      let accounts = JSON.parse(readFileSync(tempConfig.accountsFile, "utf-8"));
+      expect(accounts.activeIndex).toBe(0);
+      expect(accounts.accounts[0].refreshToken).toBe("token-personal");
+      expect(accounts.activeIndexByFamily.gemini).toBe(0);
+      expect(getCurrentRefreshToken()).toBe("token-personal");
+    
+      // 5. Use the "work" profile
+      useProfile("work");
+    
+      // 6. Verify that the activeIndex in antigravity-accounts.json is 0 and work token is first
+      accounts = JSON.parse(readFileSync(tempConfig.accountsFile, "utf-8"));
+      expect(accounts.activeIndex).toBe(0);
+      expect(accounts.accounts[0].refreshToken).toBe("token-work");
+      expect(accounts.activeIndexByFamily.gemini).toBe(0);
+      expect(getCurrentRefreshToken()).toBe("token-work");
+    });
+  });
+
+  describe("deleteProfile", () => {
+    it("should fail for non-existent profile", () => {
+      const result = deleteProfile("nonexistent");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("not found");
+    });
+
+    it("should delete profile", () => {
+      createMockAccountsFile(tempConfig, "token");
+      saveProfile("work", "project");
+      expect(listProfiles()).toHaveLength(1);
+
+      const result = deleteProfile("work");
+      expect(result.success).toBe(true);
+      expect(result.profile?.name).toBe("work");
+      expect(listProfiles()).toHaveLength(0);
+    });
+
+    it("should clear active profile if deleted", () => {
+      createMockAccountsFile(tempConfig, "token");
+      saveProfile("work", "project");
+      expect(getActiveProfileName()).toBe("work");
+
+      deleteProfile("work");
+      expect(getActiveProfileName()).toBeUndefined();
+    });
+
+    it("should not affect other profiles", () => {
+      createMockAccountsFile(tempConfig, "token-1");
+      saveProfile("work", "project-1");
+
+      createMockAccountsFile(tempConfig, "token-2");
+      saveProfile("personal", "project-2");
+
+      deleteProfile("work");
+
+      expect(listProfiles()).toHaveLength(1);
+      expect(getProfile("personal")).toBeDefined();
+    });
+  });
+
+  describe("currentInfo", () => {
+    it("should return undefined values when nothing configured", () => {
+      const info = currentInfo();
+      expect(info.refreshToken).toBeUndefined();
+      expect(info.projectId).toBeUndefined();
+      expect(info.activeProfile).toBeUndefined();
+    });
+
+    it("should return current configuration", () => {
+      createMockAccountsFile(tempConfig, "token-12345678901234567890-rest");
+      createMockConfigFile(tempConfig, "my-project");
+      saveProfile("work", "my-project");
+
+      const info = currentInfo();
+      // refreshToken is truncated to first 20 chars + "..."
+      expect(info.refreshToken).toBe("token-12345678901234...");
+      expect(info.projectId).toBe("my-project");
+      expect(info.activeProfile).toBe("work");
+    });
+  });
+
+  describe("loadProfilesStore / saveProfilesStore", () => {
+    it("should return empty store when file does not exist", () => {
+      const store = loadProfilesStore();
+      expect(store.version).toBe(1);
+      expect(store.profiles).toEqual([]);
+    });
+
+    it("should save and load profiles", () => {
+      const store = {
+        version: 1,
+        profiles: [
+          { name: "test", refreshToken: "t", projectId: "p", createdAt: 123 },
+        ],
+        activeProfile: "test",
+      };
+      saveProfilesStore(store);
+
+      const loaded = loadProfilesStore();
+      expect(loaded.version).toBe(1);
+      expect(loaded.profiles).toHaveLength(1);
+      expect(loaded.profiles[0]?.name).toBe("test");
+      expect(loaded.activeProfile).toBe("test");
+    });
+
+    it("should handle corrupted JSON gracefully", () => {
+      writeFileSync(tempConfig.profilesFile, "corrupted");
+      const store = loadProfilesStore();
+      expect(store.profiles).toEqual([]);
+    });
+  });
+
+  describe("integration: full workflow", () => {
+    it("should support complete multi-account workflow", () => {
+      // Setup account 1
+      createMockAccountsFile(tempConfig, "refresh-token-account1");
+      createMockConfigFile(tempConfig, "project-account1");
+
+      // Save as profile 1
+      let result = saveProfile("account1");
+      expect(result.success).toBe(true);
+
+      // Simulate login with account 2
+      createMockAccountsFile(tempConfig, "refresh-token-account2");
+
+      // Save as profile 2
+      result = saveProfile("account2", "project-account2");
+      expect(result.success).toBe(true);
+
+      // Verify both profiles exist
+      expect(listProfiles()).toHaveLength(2);
+      expect(getActiveProfileName()).toBe("account2");
+
+      // Switch to account 1
+      result = useProfile("account1");
+      expect(result.success).toBe(true);
+      expect(getCurrentRefreshToken()).toBe("refresh-token-account1");
+      expect(getCurrentProjectId()).toBe("project-account1");
+      expect(getActiveProfileName()).toBe("account1");
+
+      // Switch back to account 2
+      result = useProfile("account2");
+      expect(result.success).toBe(true);
+      expect(getCurrentRefreshToken()).toBe("refresh-token-account2");
+      expect(getCurrentProjectId()).toBe("project-account2");
+      expect(getActiveProfileName()).toBe("account2");
+
+      // Delete account 1
+      result = deleteProfile("account1");
+      expect(result.success).toBe(true);
+      expect(listProfiles()).toHaveLength(1);
+
+      // account2 should still be active
+      expect(getActiveProfileName()).toBe("account2");
+    });
+  });
+});

--- a/src/plugin/profiles.ts
+++ b/src/plugin/profiles.ts
@@ -1,0 +1,408 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * A named profile containing OAuth credentials and project configuration.
+ */
+export interface Profile {
+  name: string;
+  refreshToken: string;
+  projectId: string;
+  createdAt: number;
+  lastUsed?: number;
+}
+
+/**
+ * Storage format for profiles file.
+ */
+export interface ProfilesStore {
+  version: number;
+  profiles: Profile[];
+  activeProfile?: string;
+}
+
+/**
+ * Result of a profile operation.
+ */
+export interface ProfileResult {
+  success: boolean;
+  message: string;
+  profile?: Profile;
+}
+
+/**
+ * Configuration for the profile manager paths.
+ */
+export interface ProfileManagerConfig {
+  configDir: string;
+  profilesFile: string;
+  accountsFile: string;
+  configFile: string;
+}
+
+/**
+ * Returns default config paths using the user's home directory.
+ */
+export function getDefaultConfig(): ProfileManagerConfig {
+  const configDir = join(homedir(), ".config", "opencode");
+  return {
+    configDir,
+    profilesFile: join(configDir, "gemini-profiles.json"),
+    accountsFile: join(configDir, "antigravity-accounts.json"),
+    configFile: join(configDir, "config.json"),
+  };
+}
+
+// Default config - can be overridden for testing
+let currentConfig: ProfileManagerConfig = getDefaultConfig();
+
+/**
+ * Sets the configuration paths. Used for testing with temp directories.
+ */
+export function setConfig(config: ProfileManagerConfig): void {
+  currentConfig = config;
+}
+
+/**
+ * Resets to default configuration.
+ */
+export function resetConfig(): void {
+  currentConfig = getDefaultConfig();
+}
+
+/**
+ * Gets current configuration.
+ */
+export function getConfig(): ProfileManagerConfig {
+  return currentConfig;
+}
+
+/**
+ * Ensures the config directory exists.
+ */
+function ensureConfigDir(): void {
+  if (!existsSync(currentConfig.configDir)) {
+    mkdirSync(currentConfig.configDir, { recursive: true });
+  }
+}
+
+/**
+ * Loads the profiles store from disk.
+ */
+export function loadProfilesStore(): ProfilesStore {
+  ensureConfigDir();
+  if (!existsSync(currentConfig.profilesFile)) {
+    return { version: 1, profiles: [] };
+  }
+  try {
+    const content = readFileSync(currentConfig.profilesFile, "utf-8");
+    return JSON.parse(content) as ProfilesStore;
+  } catch {
+    return { version: 1, profiles: [] };
+  }
+}
+
+/**
+ * Saves the profiles store to disk.
+ */
+export function saveProfilesStore(store: ProfilesStore): void {
+  ensureConfigDir();
+  writeFileSync(currentConfig.profilesFile, JSON.stringify(store, null, 2));
+}
+
+/**
+ * Reads current refresh token from antigravity-accounts.json.
+ */
+export function getCurrentRefreshToken(): string | undefined {
+  if (!existsSync(currentConfig.accountsFile)) {
+    return undefined;
+  }
+  try {
+    const content = readFileSync(currentConfig.accountsFile, "utf-8");
+    const data = JSON.parse(content) as {
+      accounts?: Array<{ refreshToken?: string }>;
+      activeIndex?: number;
+    };
+    const activeIndex = data.activeIndex ?? 0;
+    return data.accounts?.[activeIndex]?.refreshToken;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Reads current project ID from config.json.
+ */
+export function getCurrentProjectId(): string | undefined {
+  if (!existsSync(currentConfig.configFile)) {
+    return undefined;
+  }
+  try {
+    const content = readFileSync(currentConfig.configFile, "utf-8");
+    const data = JSON.parse(content) as {
+      provider?: {
+        google?: {
+          options?: {
+            projectId?: string;
+          };
+        };
+      };
+    };
+    return data.provider?.google?.options?.projectId;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Updates the refresh token in antigravity-accounts.json.
+ */
+export function setRefreshToken(refreshToken: string): boolean {
+  try {
+    ensureConfigDir();
+    let data: {
+      version: number;
+      accounts: Array<{ refreshToken: string; addedAt: number; lastUsed: number; rateLimitResetTimes: Record<string, unknown> }>;
+      activeIndex: number;
+      activeIndexByFamily: Record<string, number>;
+    };
+
+    if (existsSync(currentConfig.accountsFile)) {
+      const content = readFileSync(currentConfig.accountsFile, "utf-8");
+      data = JSON.parse(content);
+    } else {
+      data = {
+        version: 3,
+        accounts: [],
+        activeIndex: 0,
+        activeIndexByFamily: { claude: 0, gemini: 0 },
+      };
+    }
+
+    // Find account with matching token
+    let accountIndex = data.accounts.findIndex(
+      (acc) => acc.refreshToken === refreshToken
+    );
+
+    let activeAccount;
+    if (accountIndex !== -1) {
+      // Account exists, remove it from its current position
+      [activeAccount] = data.accounts.splice(accountIndex, 1);
+    } else {
+      // Account doesn't exist, create it
+      activeAccount = {
+        refreshToken,
+        addedAt: Date.now(),
+        lastUsed: Date.now(),
+        rateLimitResetTimes: {},
+      };
+    }
+
+    // Always put the active account at index 0 to ensure it's picked up by opencode
+    activeAccount.lastUsed = Date.now();
+    data.accounts.unshift(activeAccount);
+    data.activeIndex = 0;
+
+    // Update all family indices to point to the active account (index 0)
+    for (const family of Object.keys(data.activeIndexByFamily)) {
+      data.activeIndexByFamily[family] = 0;
+    }
+
+    writeFileSync(currentConfig.accountsFile, JSON.stringify(data, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Updates the project ID in config.json.
+ */
+export function setProjectId(projectId: string): boolean {
+  try {
+    ensureConfigDir();
+    let data: Record<string, unknown> = {};
+
+    if (existsSync(currentConfig.configFile)) {
+      const content = readFileSync(currentConfig.configFile, "utf-8");
+      data = JSON.parse(content);
+    }
+
+    // Ensure nested structure exists
+    if (!data.provider) {
+      data.provider = {};
+    }
+    const provider = data.provider as Record<string, unknown>;
+    if (!provider.google) {
+      provider.google = {};
+    }
+    const google = provider.google as Record<string, unknown>;
+    if (!google.options) {
+      google.options = {};
+    }
+    const options = google.options as Record<string, unknown>;
+    options.projectId = projectId;
+
+    writeFileSync(currentConfig.configFile, JSON.stringify(data, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Lists all saved profiles.
+ */
+export function listProfiles(): Profile[] {
+  const store = loadProfilesStore();
+  return store.profiles;
+}
+
+/**
+ * Gets the currently active profile name.
+ */
+export function getActiveProfileName(): string | undefined {
+  const store = loadProfilesStore();
+  return store.activeProfile;
+}
+
+/**
+ * Gets a profile by name.
+ */
+export function getProfile(name: string): Profile | undefined {
+  const store = loadProfilesStore();
+  return store.profiles.find((p) => p.name === name);
+}
+
+/**
+ * Saves the current configuration as a named profile.
+ */
+export function saveProfile(name: string, projectId?: string): ProfileResult {
+  const refreshToken = getCurrentRefreshToken();
+  if (!refreshToken) {
+    return {
+      success: false,
+      message: "No active OAuth session found. Run 'opencode auth login' first.",
+    };
+  }
+
+  const resolvedProjectId = projectId ?? getCurrentProjectId() ?? "";
+  if (!resolvedProjectId) {
+    return {
+      success: false,
+      message: "No project ID found. Provide one as argument or set in config.json.",
+    };
+  }
+
+  const store = loadProfilesStore();
+  const existingIndex = store.profiles.findIndex((p) => p.name === name);
+  const existingProfile = existingIndex >= 0 ? store.profiles[existingIndex] : undefined;
+
+  const profile: Profile = {
+    name,
+    refreshToken,
+    projectId: resolvedProjectId,
+    createdAt: existingProfile?.createdAt ?? Date.now(),
+    lastUsed: Date.now(),
+  };
+
+  if (existingIndex >= 0) {
+    store.profiles[existingIndex] = profile;
+  } else {
+    store.profiles.push(profile);
+  }
+
+  store.activeProfile = name;
+  saveProfilesStore(store);
+
+  return {
+    success: true,
+    message: `Profile '${name}' saved (projectId: ${resolvedProjectId})`,
+    profile,
+  };
+}
+
+/**
+ * Switches to a named profile.
+ */
+export function useProfile(name: string): ProfileResult {
+  const store = loadProfilesStore();
+  const profile = store.profiles.find((p) => p.name === name);
+
+  if (!profile) {
+    const available = store.profiles.map((p) => p.name).join(", ") || "(none)";
+    return {
+      success: false,
+      message: `Profile '${name}' not found. Available: ${available}`,
+    };
+  }
+
+  // Update refresh token
+  if (!setRefreshToken(profile.refreshToken)) {
+    return {
+      success: false,
+      message: "Failed to update refresh token in accounts file.",
+    };
+  }
+
+  // Update project ID
+  if (!setProjectId(profile.projectId)) {
+    return {
+      success: false,
+      message: "Failed to update project ID in config file.",
+    };
+  }
+
+  // Update last used and active profile
+  profile.lastUsed = Date.now();
+  store.activeProfile = name;
+  saveProfilesStore(store);
+
+  return {
+    success: true,
+    message: `Switched to profile '${name}' (projectId: ${profile.projectId})`,
+    profile,
+  };
+}
+
+/**
+ * Deletes a profile by name.
+ */
+export function deleteProfile(name: string): ProfileResult {
+  const store = loadProfilesStore();
+  const index = store.profiles.findIndex((p) => p.name === name);
+
+  if (index < 0) {
+    return {
+      success: false,
+      message: `Profile '${name}' not found.`,
+    };
+  }
+
+  const [removed] = store.profiles.splice(index, 1);
+
+  if (store.activeProfile === name) {
+    store.activeProfile = undefined;
+  }
+
+  saveProfilesStore(store);
+
+  return {
+    success: true,
+    message: `Profile '${name}' deleted.`,
+    profile: removed,
+  };
+}
+
+/**
+ * Shows current configuration info.
+ */
+export function currentInfo(): { refreshToken?: string; projectId?: string; activeProfile?: string } {
+  const token = getCurrentRefreshToken();
+  return {
+    refreshToken: token ? token.slice(0, 20) + "..." : undefined,
+    projectId: getCurrentProjectId(),
+    activeProfile: getActiveProfileName(),
+  };
+}

--- a/src/plugin/token.ts
+++ b/src/plugin/token.ts
@@ -145,13 +145,15 @@ export async function refreshAccessToken(
     storeCachedAuth(updatedAuth);
     invalidateProjectContextCache(auth.refresh);
 
-    try {
-      await client.auth.set({
-        path: { id: GEMINI_PROVIDER_ID },
-        body: updatedAuth,
-      });
-    } catch (storeError) {
-      console.error("Failed to persist refreshed Gemini OAuth credentials:", storeError);
+    if (payload.refresh_token) {
+      try {
+        await client.auth.set({
+          path: { id: GEMINI_PROVIDER_ID },
+          body: updatedAuth,
+        });
+      } catch (storeError) {
+        console.error("Failed to persist refreshed Gemini OAuth credentials:", storeError);
+      }
     }
 
     return updatedAuth;


### PR DESCRIPTION
## Summary

This PR adds the ability to save and switch between multiple Google account profiles, making it easy to use different accounts/projects with opencode.

### Features

- `gemini-swap save <name> [projectId]` - Save current OAuth config as named profile
- `gemini-swap use <name>` - Switch to a saved profile  
- `gemini-swap list` - List all saved profiles
- `gemini-swap delete <name>` - Delete a profile
- `gemini-swap current` - Show current configuration

### Use Case

Users who have multiple Google accounts (work, personal, etc.) can now easily switch between them without re-authenticating each time.

### Example Workflow

```bash
# Login with first Google account
opencode auth login

# Save as profile
gemini-swap save work my-work-project-id

# Login with second Google account  
opencode auth login

# Save as another profile
gemini-swap save personal my-personal-project-id

# Now switch anytime:
gemini-swap use work
gemini-swap use personal
```

## New Files

- `src/plugin/profiles.ts` - Profile management module
- `src/plugin/profiles.test.ts` - 42 comprehensive tests
- `src/cli.ts` - CLI tool for profile management

## Changes

- `index.ts` - Export profile management functions
- `package.json` - Add bin entry for gemini-swap CLI
- `README.md` - Document account switching feature

## Test plan

- [x] All 42 new tests pass
- [x] Tests use isolated temp directories (don't touch real config)
- [x] TypeScript compiles without errors
- [x] CLI works correctly