### PR TITLE
fix: map Gemini 3.1 preview models to supported 3.x aliases

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,7 +30,7 @@ export const GEMINI_CODE_ASSIST_ENDPOINT = "https://cloudcode-pa.googleapis.com"
 export const CODE_ASSIST_HEADERS = {
   "User-Agent": "google-api-nodejs-client/9.15.1",
   "X-Goog-Api-Client": "gl-node/22.17.0",
-  "Client-Metadata": "ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI",
+  "Client-Metadata": "ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI,updateChannel=PREVIEW",
 } as const;
 
 /**

--- a/src/plugin/request/prepare.ts
+++ b/src/plugin/request/prepare.ts
@@ -9,6 +9,9 @@ import { isGenerativeLanguageRequest, toRequestUrlString } from "./shared";
 const STREAM_ACTION = "streamGenerateContent";
 const MODEL_FALLBACKS: Record<string, string> = {
   "gemini-2.5-flash-image": "gemini-2.5-flash",
+  "gemini-3.1-pro-preview": "gemini-3-pro-preview",
+  "gemini-3.1-flash-preview": "gemini-3-flash-preview",
+  "gemini-3.1-pro-preview-customtools": "gemini-3-pro-preview",
 };
 
 /**


### PR DESCRIPTION
## Summary
- When users log in through **Google Auth / Google Workspace Auth**, the Code Assist API (`cloudcode-pa.googleapis.com`) is used as the backend.
- The `gemini-3.1-pro-preview` and `gemini-3.1-flash-preview` models introduced in Opencode return `404 Not Found` when sent directly to this backend because it currently expects the legacy alias (`gemini-3-pro-preview` / `gemini-3-flash-preview`).
- When a `404` is returned for any model matching `gemini-3`, the plugin's `rewriteGeminiPreviewAccessError` incorrectly enhances the error to say: `Requested entity was not found. Request preview access at https://goo.gle/enable-preview-features before using Gemini 3 models.` which is misleading, as the user might already have preview access enabled in their Google Workspace/Cloud project.
- By adding the 3.1 aliases to `MODEL_FALLBACKS`, the plugin correctly rewrites the model ID in the payload to the recognized 3.x alias before dispatching it to the backend.
- Additionally, added `updateChannel=PREVIEW` to the `Client-Metadata` headers to align with the backend's validation rules for preview models.

## Context
This PR was generated via an AI conversation in Opencode to reverse engineer why the new `3.1` models were giving "preview access denied" errors despite access being enabled for Google Workspace users.
1. Investigating `gemini-cli-core` revealed that the Code Assist API (`cloudcode-pa.googleapis.com/v1internal:generateContent`) only validates and accepts the models `gemini-3-pro-preview` and `gemini-3-flash-preview` for preview accounts. 
2. The `opencode-gemini-auth` plugin was requesting the `3.1` model IDs exactly as they appear in the UI, which triggered a 404.
3. The plugin masks the 404 response with a generic "Request preview access" error. 
4. The fix leverages the existing `MODEL_FALLBACKS` mapping to normalize the IDs back to the supported 3.x aliases before dispatch.