### PR TITLE
fix: preserve full OpenCode provider cost shape including cache fields

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -195,13 +195,42 @@ export const GoogleOAuthPlugin = GeminiCLIOAuthPlugin;
 const loggedQuotaModelsByProject = new Set<string>();
 
 function normalizeProviderModelCosts(provider: Provider): void {
-  if (!provider.models) {
+  if (!provider?.models || typeof provider.models !== "object") {
     return;
   }
-  for (const model of Object.values(provider.models)) {
-    if (model) {
-      model.cost = { input: 0, output: 0 };
+  for (const [modelId, model] of Object.entries(provider.models)) {
+    if (!model || typeof model !== "object") {
+      continue;
     }
+    // Preserve existing cost fields while ensuring required fields exist
+    const existingCost = model.cost;
+    const isValidCost =
+      existingCost &&
+      typeof existingCost === "object" &&
+      typeof existingCost.input === "number" &&
+      typeof existingCost.output === "number";
+    // Build full OpenCode cost shape including cache fields
+    const normalizedCost = {
+      input: isValidCost ? existingCost.input : 0,
+      output: isValidCost ? existingCost.output : 0,
+      cache: {
+        read:
+          isValidCost &&
+          typeof existingCost.cache === "object" &&
+          existingCost.cache !== null &&
+          typeof (existingCost.cache as { read?: number }).read === "number"
+            ? (existingCost.cache as { read: number }).read
+            : 0,
+        write:
+          isValidCost &&
+          typeof existingCost.cache === "object" &&
+          existingCost.cache !== null &&
+          typeof (existingCost.cache as { write?: number }).write === "number"
+            ? (existingCost.cache as { write: number }).write
+            : 0,
+      },
+    };
+    model.cost = normalizedCost;
   }
 }
 

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -22,6 +22,10 @@ export interface ProviderModel {
   cost?: {
     input: number;
     output: number;
+    cache?: {
+      read: number;
+      write: number;
+    };
   };
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary

This PR fixes the `normalizeProviderModelCosts` function in `auth.loader` to preserve the full OpenCode provider cost shape, including cache-related fields.

## Problem

The original implementation was setting `model.cost = { input: 0, output: 0 }`, which:
1. Overwrote any existing cost data instead of preserving valid fields
2. Did not include the `cache: { read: number, write: number }` field that OpenCode expects
3. Could potentially poison invalid provider metadata by not validating inputs

## Solution

The fix:
- Validates the provider and model objects before modification
- Preserves existing valid cost fields (input, output)
- Preserves existing valid cache fields (read, write)
- Adds default cache: { read: 0, write: 0 } when not present
- Updates the ProviderModel type to include the optional cache field

## Testing

- All existing tests pass (55 pass)
- The type definitions have been updated to match the OpenCode provider cost shape

## Files Changed

- `src/plugin.ts`: Updated `normalizeProviderModelCosts` function
- `src/plugin/types.ts`: Added cache field to ProviderModel cost type